### PR TITLE
Fix: Activity start fail; Fix: rescaling of dots unaffected by screen height

### DIFF
--- a/ReflectionActivity.py
+++ b/ReflectionActivity.py
@@ -34,7 +34,7 @@ try:
     from sugar3.presence.wrapper import CollabWrapper
     logging.error('USING SUGAR COLLAB WRAPPER!')
 except ImportError:
-    from collabwrapper.collabwrapper import CollabWrapper
+    from collabwrapper import CollabWrapper
 
 from gettext import gettext as _
 

--- a/game.py
+++ b/game.py
@@ -22,8 +22,7 @@ import logging
 _logger = logging.getLogger('reflection-activity')
 
 try:
-    from sugar3.graphics import style
-    GRID_CELL_SIZE = style.GRID_CELL_SIZE
+    from sugar3.graphics.style import GRID_CELL_SIZE
 except ImportError:
     GRID_CELL_SIZE = 0
 
@@ -65,8 +64,12 @@ class Game():
         self._canvas.connect("button-release-event", self._button_release_cb)
         self._canvas.connect("motion-notify-event", self._mouse_move_cb)
         self._width = Gdk.Screen.width()
-        self._height = Gdk.Screen.height() - (GRID_CELL_SIZE * 1.5)
-        self._scale = self._width / (10 * DOT_SIZE * 1.2)
+        self._height = Gdk.Screen.height() - GRID_CELL_SIZE
+
+        scale = [self._width / (10 * DOT_SIZE * 1.2),
+                 self._height / (6 * DOT_SIZE * 1.2)]
+        self._scale = min(scale)
+
         self._dot_size = int(DOT_SIZE * self._scale)
         self._space = int(self._dot_size / 5.)
         self._orientation = 'horizontal'

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ if len(sys.argv) > 1 and '--no-sugar' == sys.argv[1]:
            data_files = DATA_FILES,
            )
 else: 
-    from sugar.activity import bundlebuilder
+    from sugar3.activity import bundlebuilder
 
     if __name__ == "__main__":
         bundlebuilder.start()


### PR DESCRIPTION
**Fixed in this PR:**
 - Activity start fail:
   - Due to import error
    `No module named collabwrapper`
 - Rescaling of dots unaffected by screen height:
   - Dots were rescaled only by screen width and not by screen height. Some dots were cutout for resolutiotions with less height
     Eg: 1200x600
 - Port setup.py to Sugar toolkit+3:

**Tested:**
 - on Sugar 0.112. Ubuntu 16.04(rdesktop)
 - Logs didn't show any errors attributing to the current changes

@walterbender Kindly review, thanks